### PR TITLE
Bumped version to 0.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "robotframework-find-unused"
-version = "0.2.0"
+version = "0.3.0"
 description = "Find unused parts of your Robot Framework project"
 readme = "./README.md"
 authors = [{ name = "Sander van Beek" }]


### PR DESCRIPTION
Closes #43 

## Changelog

### Features

- All commands
  - Now exits with error when no files are parsed
  - Changed output logs
    - Now warning when nothing was counted
    - Added double verbose (e.g. `--verbose --verbose` or `-vv`)
    - Rewrote log lines
  - Process now exits with exit code
    - Exit code == number of unused keywords/returns/variables/arguments
      - Maximum exit code: 200
    - When the program runs into a bad state, it exits with code 250
  - Reduced dependency on Robocop
    - Now only used for initial file discovery
- Returns command
  - Removed limitation: Library keywords are now included
  - Removed limitation: Downloaded library keywords can now be included
- Keywords command
  - Remove limitation: Can now output unused keywords of downloaded library keywords
- Arguments command
  - Remove limitation: Can now output unused keywords of downloaded library keywords

### Documentation

- Updated Readme
  - Command line options now reflect reality
  - Added newly added command line options

### Tests

- Updated internal testing framework
- Improved tests
